### PR TITLE
デプロイ環境でもローカルと同じエラーメッセージが見えるように編集

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -11,7 +11,7 @@ Rails.application.configure do
   config.eager_load = true
 
   # Full error reports are disabled and caching is turned on.
-  config.consider_all_requests_local       = false
+  config.consider_all_requests_local       = true
   config.action_controller.perform_caching = true
 
   # Disable serving static files from the `/public` folder by default since


### PR DESCRIPTION
#What
config.consider_all_requests_local       = false を　=trueに変更

#why
heroku上でエラーメッセージを確認するため